### PR TITLE
Reduce the Number of Stored Results

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -78,7 +78,7 @@ func (c *client) check() {
 
 		c.results = append(c.results, result)
 
-		if len(c.results) > 3600 {
+		if len(c.results) > 1000 {
 			c.results = c.results[1:]
 		}
 	}()


### PR DESCRIPTION
This commit reduces the number of stored results from 3600 to 1000,
which should still be more then enough 🤞.
