### PR TITLE
Add Authentication Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,25 @@ Usage of httpmonitor:
         The interval to run the HTTP checks. (default 5s)
   -method string
         The HTTP method to use for the checks. (default "GET")
+  -password string
+        The password which should used, when the target requires basic authentication.
   -timeout duration
         The timeout for the HTTP checks. (default 2s)
+  -token string
+        The token which should used, when the target requires token authentication.
   -url string
-        The url to monitor.
+        The url of the target to monitor.
+  -username string
+        The username which should used, when the target requires basic authentication.
 ```
 
-To monitor a single url, the following command can be used:
+To monitor a single target, the following command can be used:
 
 ```sh
 httpmonitor -url https://example.com -interval 1s
 ```
 
-To monitor multiple urls, a configuration file can be used:
+To monitor multiple targets, a configuration file can be used:
 
 ```yaml
 targets:

--- a/main.go
+++ b/main.go
@@ -25,16 +25,22 @@ func main() {
 	var timeout time.Duration
 	var method string
 	var body string
+	var username string
+	var password string
+	var token string
 
 	flag.StringVar(&configFile, "config", home+"/.httpmonitor.yaml", "The path to the configuration file.")
-	flag.StringVar(&url, "url", "", "The url to monitor.")
+	flag.StringVar(&url, "url", "", "The url of the target to monitor.")
 	flag.StringVar(&method, "method", http.MethodGet, "The HTTP method to use for the checks.")
 	flag.StringVar(&body, "body", "", "The body to send with the HTTP checks.")
+	flag.StringVar(&username, "username", "", "The username which should used, when the target requires basic authentication.")
+	flag.StringVar(&password, "password", "", "The password which should used, when the target requires basic authentication.")
+	flag.StringVar(&token, "token", "", "The token which should used, when the target requires token authentication.")
 	flag.DurationVar(&interval, "interval", 5*time.Second, "The interval to run the HTTP checks.")
 	flag.DurationVar(&timeout, "timeout", 2*time.Second, "The timeout for the HTTP checks.")
 	flag.Parse()
 
-	config, err := getConfig(configFile, url, method, body, interval, timeout)
+	config, err := getConfig(configFile, url, method, body, username, password, token, interval, timeout)
 	if err != nil {
 		log.Printf("Failed to load configuration: %#v", err)
 		os.Exit(1)
@@ -56,7 +62,7 @@ func main() {
 
 // If the url flag is set, the function will return a config with just the
 // target from the flag. Otherwise we will return the config from the file.
-func getConfig(file, url, method, body string, interval, timeout time.Duration) (*config.Config, error) {
+func getConfig(file, url, method, body, username, password, token string, interval, timeout time.Duration) (*config.Config, error) {
 	if url != "" {
 		return &config.Config{
 			Targets: []target.Config{{
@@ -64,6 +70,9 @@ func getConfig(file, url, method, body string, interval, timeout time.Duration) 
 				URL:      url,
 				Method:   method,
 				Body:     body,
+				Username: username,
+				Password: password,
+				Token:    token,
 				Interval: interval,
 				Timeout:  timeout,
 			}},


### PR DESCRIPTION
It is now possible to set the username and password or token for a
single check via the `-username`, `-password` and `-token` command-line
flags.
