### PR TITLE
Improve Content Transfer Duration in Case of a Timeout

### DIFF
--- a/pkg/target/result.go
+++ b/pkg/target/result.go
@@ -50,7 +50,12 @@ func (r *Result) End(t time.Time, statusCode int) {
 		return
 	}
 
-	r.ContentTransfer = r.transferDone.Sub(r.transferStart)
+	if statusCode == 0 && r.transferStart.IsZero() {
+		r.ContentTransfer = 0
+	} else {
+		r.ContentTransfer = r.transferDone.Sub(r.transferStart)
+	}
+
 	r.Total = r.transferDone.Sub(r.dnsStart)
 }
 


### PR DESCRIPTION
If the request runs into a timeout and the content transfer wasn't
started yet, the content transfer duration showed a weird value. This is
now fixed by setting it to `0` in such cases.
