### PR TITLE
Add `version` Field to GoReleaser Configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 ---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -16,7 +19,7 @@ builds:
       - arm64
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 archives:
   - builds:


### PR DESCRIPTION
Add `version` field to GoReleaser configuration, to fix the warning
shown in https://github.com/ricoberger/httpmonitor/actions/runs/13616950011/job/38061235384#step:4:11

```
only version: 2 configuration files are supported, yours is version: 0, please update your configuration
```
