### PR TITLE
Add `-insecure` Flag to Skip TLS Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # httpmonitor
 
-`httpmonitor` is a small TUI application to monitor a single or multiple targets.
+`httpmonitor` is a small TUI application to monitor a single or multiple
+targets.
 
 ![Overview](.github/assets/overview.png)
 
@@ -10,7 +11,8 @@
 
 ### Releases
 
-Check the [releases](https://github.com/ricoberger/httpmonitor/releases) page for the full list of pre-built binaries.
+Check the [releases](https://github.com/ricoberger/httpmonitor/releases) page
+for the full list of pre-built binaries.
 
 1. Download the release for your os/arch
 2. Unzip to archive to get the `httpmonitor` binary
@@ -30,6 +32,8 @@ Usage of httpmonitor:
         The body to send with the HTTP checks.
   -config string
         The path to the configuration file. (default "/Users/ricoberger/.httpmonitor.yaml")
+  -insecure
+        Skip TLS certificate verification.
   -interval duration
         The interval to run the HTTP checks. (default 5s)
   -method string
@@ -67,6 +71,7 @@ targets:
     username:
     password:
     token:
+    insecure: false
     notification:
     notificationThreshold:
     interval: 5s

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	var username string
 	var password string
 	var token string
+	var insecure bool
 	var notification bool
 	var notificationThreshold time.Duration
 
@@ -38,13 +39,14 @@ func main() {
 	flag.StringVar(&username, "username", "", "The username which should used, when the target requires basic authentication.")
 	flag.StringVar(&password, "password", "", "The password which should used, when the target requires basic authentication.")
 	flag.StringVar(&token, "token", "", "The token which should used, when the target requires token authentication.")
+	flag.BoolVar(&insecure, "insecure", false, "Skip TLS certificate verification.")
 	flag.BoolVar(&notification, "notification", false, "Enable desktop notifications, for failed checks.")
 	flag.DurationVar(&notificationThreshold, "notification-threshold", 0*time.Second, "Enable desktop notifications, for checks which are longer than the threshold.")
 	flag.DurationVar(&interval, "interval", 5*time.Second, "The interval to run the HTTP checks.")
 	flag.DurationVar(&timeout, "timeout", 2*time.Second, "The timeout for the HTTP checks.")
 	flag.Parse()
 
-	config, err := getConfig(configFile, url, method, body, username, password, token, notification, notificationThreshold, interval, timeout)
+	config, err := getConfig(configFile, url, method, body, username, password, token, insecure, notification, notificationThreshold, interval, timeout)
 	if err != nil {
 		log.Printf("Failed to load configuration: %#v", err)
 		os.Exit(1)
@@ -66,7 +68,7 @@ func main() {
 
 // If the url flag is set, the function will return a config with just the
 // target from the flag. Otherwise we will return the config from the file.
-func getConfig(file, url, method, body, username, password, token string, notification bool, notificationThreshold, interval, timeout time.Duration) (*config.Config, error) {
+func getConfig(file, url, method, body, username, password, token string, insecure, notification bool, notificationThreshold, interval, timeout time.Duration) (*config.Config, error) {
 	if url != "" {
 		return &config.Config{
 			Targets: []target.Config{{
@@ -77,6 +79,7 @@ func getConfig(file, url, method, body, username, password, token string, notifi
 				Username:              username,
 				Password:              password,
 				Token:                 token,
+				Insecure:              insecure,
 				Notification:          notification,
 				NotificationThreshold: notificationThreshold,
 				Interval:              interval,

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -20,6 +20,7 @@ type Config struct {
 	Username              string        `yaml:"username"`
 	Password              string        `yaml:"password"`
 	Token                 string        `yaml:"token"`
+	Insecure              bool          `yaml:"insecure"`
 	Notification          bool          `yaml:"notification"`
 	NotificationThreshold time.Duration `yaml:"notificationThreshold"`
 	Interval              time.Duration `yaml:"interval"`
@@ -133,27 +134,10 @@ func (c *client) check() {
 }
 
 func NewClient(config Config) Client {
-	roundTripper := DefaultRoundTripper
-
-	if config.Username != "" && config.Password != "" {
-		roundTripper = BasicAuthTransport{
-			Transport: roundTripper,
-			Username:  config.Username,
-			Password:  config.Password,
-		}
-	}
-
-	if config.Token != "" {
-		roundTripper = TokenAuthTransporter{
-			Transport: roundTripper,
-			Token:     config.Token,
-		}
-	}
-
 	return &client{
 		config: config,
 		httpClient: &http.Client{
-			Transport: roundTripper,
+			Transport: getRoundTripper(config),
 		},
 	}
 }


### PR DESCRIPTION
Add a new flag `-insecure` and a new configuration option `insecure` for
targets to skip TLS certificate verification.

Closes #22 